### PR TITLE
Add support for deno lockfile version 4

### DIFF
--- a/nix/mkDenoDir.nix
+++ b/nix/mkDenoDir.nix
@@ -112,7 +112,7 @@
         "npm/${npmRegistryUrlSlug}/${pkgName}/${version}" = unpacked;
         "npm/${npmRegistryUrlSlug}/${pkgName}/registry/${version}.json" = writeText "${drvName}-registry.json" registryData;
       }
-    ) (denoLock.packages.npm or {})
+    ) ((if denoLock.version == "4" then denoLock.npm else denoLock.packages.npm) or {})
   );
 in
   symlinkJoin {

--- a/nix/mkDenoDir.nix
+++ b/nix/mkDenoDir.nix
@@ -112,7 +112,7 @@
         "npm/${npmRegistryUrlSlug}/${pkgName}/${version}" = unpacked;
         "npm/${npmRegistryUrlSlug}/${pkgName}/registry/${version}.json" = writeText "${drvName}-registry.json" registryData;
       }
-    ) ((if denoLock.version == "4" then denoLock.npm else denoLock.packages.npm) or {})
+    ) (if denoLock.version == "4" then denoLock.npm or {} else denoLock.packages.npm or {})
   );
 in
   symlinkJoin {


### PR DESCRIPTION
This simple addition provides initial support for lockfile version 4. However, there's one caveat: the `node_modules/.bin` isn't populated. I suppose that missing `bin` property in `registry.json` is the reason for the issue. For my use case, I manually added the missing link and was done.